### PR TITLE
Add inline styling for BV calculator

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,15 +1,52 @@
-
 <!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>AI4Impact — 40% Share Calculator</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+  <title>{% block title %}AI4Impact — 40% Share Calculator{% endblock %}</title>
+  {% block head %}
+  <style>
+    :root{
+      --bg:#0b0f14;
+      --card:#121922;
+      --ink:#dfe8f3;
+      --muted:#97a6ba;
+      --accent:#9ad1ff;
+      --accent-strong:#4db8ff;
+      --ok:#9cffac;
+    }
+    *{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji"}
+    .container{max-width:1000px;margin:2rem auto;padding:0 1rem}
+    h1{font-size:1.75rem;margin:0 0 0.25rem 0}
+    .subtitle{color:var(--muted);margin:0 0 1.5rem 0}
+    .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem}
+    fieldset{border:1px solid #243244;border-radius:.5rem;padding:1rem;background:var(--card)}
+    legend{padding:0 .5rem;color:var(--accent)}
+    label{display:flex;flex-direction:column;gap:.35rem;color:var(--muted);font-size:.9rem}
+    input{padding:.6rem;border:1px solid #233140;border-radius:.4rem;background:#0d131b;color:var(--ink)}
+    .actions{grid-column:1/-1;display:flex;justify-content:flex-end}
+    button{padding:.8rem 1.1rem;border-radius:.4rem;border:1px solid var(--accent-strong);background:transparent;color:var(--accent);font-weight:600;cursor:pointer}
+    button:hover{background:rgba(77,184,255,.1)}
+    .results{margin-top:2rem}
+    .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem}
+    .card{background:var(--card);border:1px solid #233140;border-radius:.8rem;padding:1rem}
+    .card h3{margin-top:0;color:var(--accent)}
+    .list{list-style:none;padding:0;margin:0}
+    .list li{display:flex;justify-content:space-between;padding:.4rem 0;border-bottom:1px dashed #253545}
+    .list li:last-child{border-bottom:0}
+    .totals{margin-top:.6rem;border-top:1px solid #253545;padding-top:.6rem;display:flex;flex-direction:column;gap:.35rem}
+    .highlight{color:var(--ok);font-weight:700}
+    .big{font-size:1.25rem}
+    .summary .note{color:var(--muted);font-size:.85rem;margin-top:.5rem}
+  </style>
+  {% endblock %}
 </head>
-<body>
+<body class="{% block body_class %}{% endblock %}">
+  {% block hero %}{% endblock %}
   <main class="container">
     {% block content %}{% endblock %}
   </main>
+  {% block body_end %}{% endblock %}
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,8 @@
-
 {% extends "base.html" %}
+{% block title %}AI4Impact — Simple 40% Share Calculator{% endblock %}
+{% block head %}
+  {{ super() }}
+{% endblock %}
 {% block content %}
 <h1>AI4Impact — Simple 40% Share Calculator</h1>
 <p class="subtitle">Calculate your partner's contribution from <strong>1 Sep 2024</strong> and a forward projection.</p>


### PR DESCRIPTION
## Summary
- inline the BV colour palette and layout styles directly in `base.html`
- add templating hooks for title, hero, and body class so pages can extend the base layout
- ensure the index page reuses the shared styles by calling the base `head` block and setting its title

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e35ebb3294833198994c16e0af1153