### PR TITLE
Convert summary table to responsive card layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -36,9 +36,23 @@ button:hover{background:rgba(77,184,255,.1)}
 .summary .list li{border:1px solid #253545;border-radius:.6rem;padding:.75rem;border-bottom:0;flex-direction:column;align-items:flex-start;gap:.4rem}
 .summary .list li span{color:var(--muted);font-size:.9rem}
 .summary .list li strong{align-self:flex-end}
+.summary .share-breakdown{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:.75rem 1rem;margin-top:.75rem}
+.share-card{border:1px solid #253545;border-radius:.6rem;padding:.9rem;background:rgba(13,19,27,.6);display:flex;flex-direction:column;gap:.6rem}
+.share-card__header{display:flex;justify-content:space-between;align-items:baseline;gap:.75rem}
+.share-card__name{font-weight:600}
+.share-card__pct{color:var(--muted);font-size:.85rem}
+.share-card__figures{margin:0;display:flex;flex-direction:column;gap:.45rem}
+.share-card__figure{display:flex;justify-content:space-between;gap:.75rem;align-items:flex-start}
+.share-card__figure dt{margin:0;color:var(--muted);font-size:.85rem}
+.share-card__figure dd{margin:0;font-weight:600}
+.positive{color:var(--ok);font-weight:600}
+.negative{color:var(--warn);font-weight:600}
+.numeric{text-align:right;font-variant-numeric:tabular-nums}
 @media (max-width:900px){
   .summary .list{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .summary .share-breakdown{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
 }
 @media (max-width:600px){
   .summary .list{grid-template-columns:1fr}
+  .summary .share-breakdown{grid-template-columns:1fr}
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -44,17 +44,25 @@
     .summary .list li{border:1px solid #253545;border-radius:.6rem;padding:.75rem;border-bottom:0;flex-direction:column;align-items:flex-start;gap:.4rem}
     .summary .list li span{color:var(--muted);font-size:.9rem}
     .summary .list li strong{align-self:flex-end}
+    .summary .share-breakdown{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:.75rem 1rem;margin-top:.75rem}
+    .share-card{border:1px solid #253545;border-radius:.6rem;padding:.9rem;background:rgba(13,19,27,.6);display:flex;flex-direction:column;gap:.6rem}
+    .share-card__header{display:flex;justify-content:space-between;align-items:baseline;gap:.75rem}
+    .share-card__name{font-weight:600}
+    .share-card__pct{color:var(--muted);font-size:.85rem}
+    .share-card__figures{margin:0;display:flex;flex-direction:column;gap:.45rem}
+    .share-card__figure{display:flex;justify-content:space-between;gap:.75rem;align-items:flex-start}
+    .share-card__figure dt{margin:0;color:var(--muted);font-size:.85rem}
+    .share-card__figure dd{margin:0;font-weight:600}
+    .numeric{text-align:right;font-variant-numeric:tabular-nums}
     @media (max-width:900px){
       .summary .list{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+      .summary .share-breakdown{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
     }
     @media (max-width:600px){
       .summary .list{grid-template-columns:1fr}
+      .summary .share-breakdown{grid-template-columns:1fr}
     }
     .summary .totals.overall{margin-top:1rem;border-top:1px solid #253545;padding-top:.8rem;gap:.45rem}
-    .share-table{width:100%;border-collapse:collapse;margin-top:.75rem;font-size:.9rem}
-    .share-table th,.share-table td{padding:.45rem .5rem;border-bottom:1px solid #253545;text-align:left}
-    .share-table th{color:var(--muted);font-size:.8rem;text-transform:uppercase;letter-spacing:.05em}
-    .share-table td.numeric{text-align:right;font-variant-numeric:tabular-nums}
     .positive{color:var(--ok);font-weight:600}
     .negative{color:var(--warn);font-weight:600}
   </style>

--- a/templates/index.html
+++ b/templates/index.html
@@ -122,28 +122,30 @@
         <div><span>Company net (revenue − cost)</span><strong class="{% if display.projection_company_net_value < 0 %}negative{% else %}positive{% endif %}">{{ display.projection_company_net }}</strong></div>
       </div>
       <h4>Projection share breakdown</h4>
-      <table class="share-table">
-        <thead>
-          <tr>
-            <th>Stakeholder</th>
-            <th>Equity %</th>
-            <th class="numeric">Revenue share</th>
-            <th class="numeric">Cost share</th>
-            <th class="numeric">Net</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for row in display.summary_projection_rows %}
-          <tr>
-            <th scope="row">{{ row.name }}</th>
-            <td>{{ row.pct }}</td>
-            <td class="numeric">{{ row.revenue }}</td>
-            <td class="numeric">{{ row.cost }}</td>
-            <td class="numeric {% if row.net_value < 0 %}negative{% else %}positive{% endif %}">{{ row.net }}</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+      <div class="share-breakdown">
+        {% for row in display.summary_projection_rows %}
+        <div class="share-card">
+          <div class="share-card__header">
+            <span class="share-card__name">{{ row.name }}</span>
+            <span class="share-card__pct">{{ row.pct }}</span>
+          </div>
+          <dl class="share-card__figures">
+            <div class="share-card__figure">
+              <dt>Revenue share</dt>
+              <dd class="numeric">{{ row.revenue }}</dd>
+            </div>
+            <div class="share-card__figure">
+              <dt>Cost share</dt>
+              <dd class="numeric">{{ row.cost }}</dd>
+            </div>
+            <div class="share-card__figure">
+              <dt>Net</dt>
+              <dd class="numeric {% if row.net_value < 0 %}negative{% else %}positive{% endif %}">{{ row.net }}</dd>
+            </div>
+          </dl>
+        </div>
+        {% endfor %}
+      </div>
       <p class="note">This tool is for planning only; not legal or tax advice.</p>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- replace the summary projection table with a stacked card layout to avoid text distortion
- add new responsive styles for the share breakdown cards and numeric formatting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3725174a48331b269d18893cbaa18