### PR TITLE
Adjust grid layouts to consistently use two columns

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -13,7 +13,7 @@ body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.5 system-ui, -ap
 .container{max-width:1000px;margin:2rem auto;padding:0 1rem}
 h1{font-size:1.75rem;margin:0 0 0.25rem 0}
 .subtitle{color:var(--muted);margin:0 0 1.5rem 0}
-.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem}
+.grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:1rem}
 fieldset{border:1px solid #243244;border-radius:.5rem;padding:1rem;background:var(--card)}
 legend{padding:0 .5rem;color:var(--accent)}
 label{display:flex;flex-direction:column;gap:.35rem;color:var(--muted);font-size:.9rem}
@@ -22,7 +22,7 @@ input{padding:.6rem;border:1px solid #233140;border-radius:.4rem;background:#0d1
 button{padding:.8rem 1.1rem;border-radius:.4rem;border:1px solid var(--accent-strong);background:transparent;color:var(--accent);font-weight:600;cursor:pointer}
 button:hover{background:rgba(77,184,255,.1)}
 .results{margin-top:2rem}
-.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem}
+.cards{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:1rem}
 .card{background:var(--card);border:1px solid #233140;border-radius:.8rem;padding:1rem}
 .card h3{margin-top:0;color:var(--accent)}
 .list{list-style:none;padding:0;margin:0}
@@ -36,7 +36,7 @@ button:hover{background:rgba(77,184,255,.1)}
 .summary .list li{border:1px solid #253545;border-radius:.6rem;padding:.75rem;border-bottom:0;flex-direction:row;align-items:center;gap:.4rem}
 .summary .list li span{color:var(--muted);font-size:.9rem}
 .summary .list li strong{margin-left:auto}
-.summary .share-breakdown{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:.75rem 1rem;margin-top:.75rem}
+.summary .share-breakdown{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.75rem 1rem;margin-top:.75rem}
 .share-card{border:1px solid #253545;border-radius:.6rem;padding:.9rem;background:rgba(13,19,27,.6);display:flex;flex-direction:column;gap:.6rem}
 .share-card__header{display:flex;justify-content:space-between;align-items:baseline;gap:.75rem}
 .share-card__name{font-weight:600}
@@ -49,8 +49,12 @@ button:hover{background:rgba(77,184,255,.1)}
 .negative{color:var(--warn);font-weight:600}
 .numeric{text-align:right;font-variant-numeric:tabular-nums}
 @media (max-width:900px){
+  .grid{grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
+  .cards{grid-template-columns:repeat(auto-fit,minmax(280px,1fr))}
   .summary .share-breakdown{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
 }
 @media (max-width:600px){
+  .grid{grid-template-columns:1fr}
+  .cards{grid-template-columns:1fr}
   .summary .share-breakdown{grid-template-columns:1fr}
 }


### PR DESCRIPTION
## Summary
- update the form, results cards, and share breakdown grids to render two columns per row on wide screens
- preserve responsive behaviour by collapsing the grids to auto-fit and single-column layouts on narrower viewports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e377e7426c8331a20401e9f54ad4a7